### PR TITLE
v0.2.0: JSDoc improvements and breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@
 
 ## Imports
 
-**Latest version (v0.1.0)**
+**Latest version (v0.2.0)**
 
-- <https://deno.land/x/airtable@v0.1.0/mod.ts>
-- <https://denopkg.com/grikomsn/airtable-deno@v0.1.0/mod.ts>
+- <https://deno.land/x/airtable@v0.2.0/mod.ts>
+- <https://denopkg.com/grikomsn/airtable-deno@v0.2.0/mod.ts>
 
 **Bleeding edge (master branch)**
 

--- a/airtable.ts
+++ b/airtable.ts
@@ -17,6 +17,7 @@ import { hasAnyKey } from "./utils.ts";
  * Unofficial Airtable API client for Deno
  *
  * @author Griko Nibras <hello@griko.id>
+ * @copyright MIT License Copyright (c) 2020 [Griko Nibras](https://github.com/grikomsn)
  * @export
  * @class Airtable
  */
@@ -24,7 +25,17 @@ export class Airtable {
   #options: AirtableOptions;
 
   /**
-   * Creates an instance of Airtable
+   * Creates an instance of Airtable client
+   *
+   * ```ts
+   * const airtable = new Airtable()
+   * const airtable = new Airtable({ useEnv: true })
+   * const airtable = new Airtable({
+   *   apiKey: "keyXXXXXXXXXXXXXX",
+   *   baseId: "appXXXXXXXXXXXXXX",
+   *   tableName: "Some table name",
+   * })
+   * ```
    *
    * @param {AirtableOptions} options Airtable client configuration
    * @memberof Airtable
@@ -47,8 +58,16 @@ export class Airtable {
   /**
    * Reconfigure the Airtable client
    *
+   * ```ts
+   * airtable.configure({
+   *   apiKey: "keyXXXXXXXXXXXXXX",
+   *   baseId: "appXXXXXXXXXXXXXX",
+   *   tableName: "Some table name",
+   * })
+   * ```
+   *
    * @param {AirtableOptions} options Airtable client configuration
-   * @returns
+   * @returns {Airtable} current Airtable client
    * @memberof Airtable
    */
   configure(options: AirtableOptions): Airtable {
@@ -59,8 +78,13 @@ export class Airtable {
   /**
    * Returns new Airtable client with defined base ID
    *
+   * ```ts
+   * const airtable = new Airtable()
+   * const airtableWithNewBaseId = airtable.base("appXXXXXXXXXXXXXX")
+   * ```
+   *
    * @param {string} baseId Airtable base
-   * @returns
+   * @returns {Airtable} current Airtable client
    * @memberof Airtable
    */
   base(baseId: string): Airtable {
@@ -70,8 +94,13 @@ export class Airtable {
   /**
    * Returns new Airtable client with defined table name
    *
+   * ```ts
+   * const airtable = new Airtable()
+   * const airtableWithNewTableName = airtable.table("Some table name")
+   * ```
+   *
    * @param {string} tableName
-   * @returns
+   * @returns {Airtable} current Airtable client
    * @memberof Airtable
    */
   table(tableName: string): Airtable {
@@ -81,9 +110,13 @@ export class Airtable {
   /**
    * List records from selected base and table
    *
-   * @template T
-   * @param {SelectOptions} [options={}]
-   * @returns
+   * ```ts
+   * const results = await airtable.select()
+   * ```
+   *
+   * @template T table field types
+   * @param {SelectOptions} [options={}] select query options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<SelectResult<T>>} select query result
    * @memberof Airtable
    */
   select<T extends FieldSet<string>>(
@@ -97,9 +130,14 @@ export class Airtable {
   /**
    * Retrieve record from selected base and table
    *
-   * @template T
-   * @param {string} id
-   * @returns
+   * ```ts
+   * const record = await airtable.find("recXXXXXXXXXXXXXX")
+   * const { id, fields, createdTime } = await airtable.find("recXXXXXXXXXXXXXX")
+   * ```
+   *
+   * @template T table field types
+   * @param {string} id table record id
+   * @returns {Promise<TableRecord<T>>} table record result
    * @memberof Airtable
    */
   find<T extends FieldSet<string>>(id: string): Promise<TableRecord<T>> {
@@ -111,10 +149,17 @@ export class Airtable {
   /**
    * Create record for selected base and table
    *
-   * @template T
-   * @param {T} data
-   * @param {RecordOptions} [options]
-   * @returns {Promise<TableRecord<T>>}
+   * ```ts
+   *  const createOne = await airtable.create({
+   *    ["Name"]: "Griko Nibras",
+   *    ["Age"]: 25,
+   *  });
+   * ```
+   *
+   * @template T table field types
+   * @param {T} data record values
+   * @param {RecordOptions} [options] record creations options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<TableRecord<T>>} created record values
    * @memberof Airtable
    */
   create<T extends FieldSet<string>>(
@@ -125,10 +170,20 @@ export class Airtable {
   /**
    * Create multiple records for selected base and table
    *
-   * @template T
-   * @param {T[]} data
-   * @param {RecordOptions} [options]
-   * @returns {Promise<TableRecords<T>>}
+   * ```ts
+   * const createMultiple = await airtable.create(
+   *   [
+   *     { ["Name"]: "Foo", ["Age"]: 20 },
+   *     { ["Name"]: "Bar", ["Age"]: 15 },
+   *   ],
+   *   { typecast: true }
+   * );
+   * ```
+   *
+   * @template T table field types
+   * @param {T[]} data array of record values
+   * @param {RecordOptions} [options] record creations options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<TableRecords<T>>} array of created record values
    * @memberof Airtable
    */
   create<T extends FieldSet<string>>(
@@ -161,10 +216,26 @@ export class Airtable {
   /**
    * Update multiple for selected base and table
    *
-   * @template T
-   * @param {TableRecord<T>[]} records
-   * @param {RecordOptions} [options]
-   * @returns {Promise<TableRecords<T>>}
+   * ```ts
+   * const updateMultiple = await airtable.update(
+   *   [
+   *     {
+   *       id: "recXXXXXXXXXXXXXX",
+   *       fields: { ["Name"]: "Adult boi", ["Age"]: 30 },
+   *     },
+   *     {
+   *       id: "recXXXXXXXXXXXXXX",
+   *       fields: { ["Name"]: "Yung boi", ["Age"]: 15 },
+   *     },
+   *   ],
+   *   { typecast: true }
+   * );
+   * ```
+   *
+   * @template T table field types
+   * @param {TableRecord<T>[]} records array of record values to be updated
+   * @param {RecordOptions} [options] record updating options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<TableRecords<T>>} array of updated record values
    * @memberof Airtable
    */
   update<T extends FieldSet<string>>(
@@ -175,11 +246,18 @@ export class Airtable {
   /**
    * Update single records for selected base and table
    *
-   * @template T
-   * @param {string} id
-   * @param {T} [record]
-   * @param {RecordOptions} [options]
-   * @returns {Promise<TableRecord<T>>}
+   * ```ts
+   * const updateOne = await airtable.update("recXXXXXXXXXXXXXX", {
+   *   ["Name"]: "Adult boi",
+   *   ["Age"]: 30,
+   * });
+   * ```
+   *
+   * @template T table field types
+   * @param {string} id record id
+   * @param {T} record record values
+   * @param {RecordOptions} [options] record updating options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<TableRecords<T>>} updated record values
    * @memberof Airtable
    */
   update<T extends FieldSet<string>>(
@@ -215,10 +293,26 @@ export class Airtable {
   /**
    * Replace multiple for selected base and table
    *
-   * @template T
-   * @param {TableRecord<T>[]} records
-   * @param {RecordOptions} [options]
-   * @returns {Promise<TableRecords<T>>}
+   * ```ts
+   * const replaceMultiple = await airtable.replace(
+   *   [
+   *     {
+   *       id: "recXXXXXXXXXXXXXX",
+   *       fields: { ["Name"]: "Adult boi", ["Age"]: 30 },
+   *     },
+   *     {
+   *       id: "recXXXXXXXXXXXXXX",
+   *       fields: { ["Name"]: "Yung boi", ["Age"]: 15 },
+   *     },
+   *   ],
+   *   { typecast: true }
+   * );
+   * ```
+   *
+   * @template T table field types
+   * @param {TableRecord<T>[]} records array of record values to be replaced
+   * @param {RecordOptions} [options] record replacing options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<TableRecords<T>>} array of replaced record values
    * @memberof Airtable
    */
   replace<T extends FieldSet<string>>(
@@ -229,11 +323,18 @@ export class Airtable {
   /**
    * Replace single records for selected base and table
    *
-   * @template T
-   * @param {string} id
-   * @param {T} [record]
-   * @param {RecordOptions} [options]
-   * @returns {Promise<TableRecord<T>>}
+   * ```ts
+   * const replaceOne = await airtable.update("recXXXXXXXXXXXXXX", {
+   *   ["Name"]: "Adult boi",
+   *   ["Age"]: 30,
+   * });
+   * ```
+   *
+   * @template T table field types
+   * @param {string} id record id
+   * @param {T} record record values
+   * @param {RecordOptions} [options] record replacing options, read more on the [Airtable API documentation](https://airtable.com/api)
+   * @returns {Promise<TableRecords<T>>} replaced record values
    * @memberof Airtable
    */
   replace<T extends FieldSet<string>>(
@@ -269,8 +370,12 @@ export class Airtable {
   /**
    * Delete record from selected base and table
    *
-   * @param {string} id
-   * @returns {Promise<DeletedRecord>}
+   * ```ts
+   * const deleteOne = await airtable.delete("recXXXXXXXXXXXXXX");
+   * ```
+   *
+   * @param {string} id record id
+   * @returns {Promise<DeletedRecord>} deleted record result
    * @memberof Airtable
    */
   delete(id: string): Promise<DeletedRecord>;
@@ -278,8 +383,15 @@ export class Airtable {
   /**
    * Delete multiple records from selected base and table
    *
-   * @param {string[]} ids
-   * @returns {Promise<DeletedRecords>}
+   * ```ts
+   * const deleteMultiple = await airtable.delete([
+   *   "recXXXXXXXXXXXXXX",
+   *   "recXXXXXXXXXXXXXX",
+   * ]);
+   * ```
+   *
+   * @param {string[]} ids record ids
+   * @returns {Promise<DeletedRecords>} deleted records result
    * @memberof Airtable
    */
   delete(ids: string[]): Promise<DeletedRecords>;

--- a/airtable.ts
+++ b/airtable.ts
@@ -51,7 +51,7 @@ export class Airtable {
    * @returns
    * @memberof Airtable
    */
-  configure(options: AirtableOptions) {
+  configure(options: AirtableOptions): Airtable {
     this.#options = { ...this.#options, ...options };
     return this;
   }
@@ -63,7 +63,7 @@ export class Airtable {
    * @returns
    * @memberof Airtable
    */
-  base(baseId: string) {
+  base(baseId: string): Airtable {
     this.#options.baseId = baseId;
     return this;
   }
@@ -75,7 +75,7 @@ export class Airtable {
    * @returns
    * @memberof Airtable
    */
-  table(tableName: string) {
+  table(tableName: string): Airtable {
     this.#options.tableName = tableName;
     return this;
   }
@@ -88,7 +88,9 @@ export class Airtable {
    * @returns
    * @memberof Airtable
    */
-  select<T extends FieldSet<string>>(options: SelectOptions<keyof T> = {}) {
+  select<T extends FieldSet<string>>(
+    options: SelectOptions<keyof T> = {}
+  ): Promise<SelectResult<T>> {
     return this.request<SelectResult<T>>({
       url: this.getRequestUrl(options),
     });
@@ -102,7 +104,7 @@ export class Airtable {
    * @returns
    * @memberof Airtable
    */
-  find<T extends FieldSet<string>>(id: string) {
+  find<T extends FieldSet<string>>(id: string): Promise<TableRecord<T>> {
     return this.request<TableRecord<T>>({
       url: this.getRequestUrl({}, id),
     });
@@ -184,7 +186,7 @@ export class Airtable {
    */
   update<T extends FieldSet<string>>(
     id: string,
-    record?: T,
+    record: T,
     options?: RecordOptions
   ): Promise<TableRecord<T>>;
 
@@ -238,7 +240,7 @@ export class Airtable {
    */
   replace<T extends FieldSet<string>>(
     id: string,
-    record?: T,
+    record: T,
     options?: RecordOptions
   ): Promise<TableRecord<T>>;
 

--- a/airtable.ts
+++ b/airtable.ts
@@ -29,7 +29,7 @@ export class Airtable {
    * @param {AirtableOptions} options Airtable client configuration
    * @memberof Airtable
    */
-  constructor(options: AirtableOptions) {
+  constructor(options: AirtableOptions = {}) {
     this.#options = {
       ...(options.useEnv
         ? {

--- a/airtable.ts
+++ b/airtable.ts
@@ -57,27 +57,25 @@ export class Airtable {
   }
 
   /**
-   * Set the Airtable client base ID
+   * Returns new Airtable client with defined base ID
    *
    * @param {string} baseId Airtable base
    * @returns
    * @memberof Airtable
    */
   base(baseId: string): Airtable {
-    this.#options.baseId = baseId;
-    return this;
+    return new Airtable({ ...this.#options, baseId });
   }
 
   /**
-   * Set the Airtable table name
+   * Returns new Airtable client with defined table name
    *
    * @param {string} tableName
    * @returns
    * @memberof Airtable
    */
   table(tableName: string): Airtable {
-    this.#options.tableName = tableName;
-    return this;
+    return new Airtable({ ...this.#options, tableName });
   }
 
   /**


### PR DESCRIPTION
This PR updates to v0.2.0 with changes listed below:

## Improvements

- Updated JSDoc with examples

## Breaking

- Changed `base` and `table` method to return new `Airtable` instance rather than updating itself