### PR TITLE
Type Fix: Change Attachment FieldSet type to an Array

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -65,7 +65,7 @@ export interface FieldSet<T extends string = string> {
     | Field.SingleSelect<T>
     | Field.Collaborator
     | Field.Collaborators
-    | Field.Attachment
+    | Field.Attachment[]
     | Field.DateType
     | Field.PhoneNumber
     | Field.Email


### PR DESCRIPTION
From what I can tell, a field of type 'Attachment' will always return an array. It returns an array even if the data only contains one attachment. This PR updates the typings to match.