### PR TITLE
fix: airtable.select() for cases with query string options

### DIFF
--- a/airtable.test.ts
+++ b/airtable.test.ts
@@ -1,0 +1,46 @@
+import { Airtable } from "./airtable.ts";
+import { assertEquals } from "./deps.ts";
+
+const airtable = new Airtable({
+  apiKey: "keyXXXXXXXXXXXXXX",
+  baseId: "appXXXXXXXXXXXXXX",
+  tableName: "Humans",
+});
+
+Deno.test("getRequestUrl - applies an id as a URL segment", async () => {
+  const id = "recXXXXXXXXXXXXXX";
+  assertEquals(
+    airtable.getRequestUrl({}, id),
+    "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans/recXXXXXXXXXXXXXX"
+  );
+});
+
+Deno.test(
+  "getRequestUrl - applies filterByFormula as a query param",
+  async () => {
+    assertEquals(
+      decodeURIComponent(
+        airtable.getRequestUrl({
+          filterByFormula: "{Age}='27'",
+        })
+      ),
+      "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans?filterByFormula={Age}='27'"
+    );
+  }
+);
+
+Deno.test(
+  "getRequestUrl - applies multiple query params correctly",
+  async () => {
+    assertEquals(
+      decodeURIComponent(
+        airtable.getRequestUrl({
+          filterByFormula: "{Age}='27'",
+          maxRecords: "50",
+          pageSize: 30,
+        })
+      ),
+      "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans?filterByFormula={Age}='27'&maxRecords=50&pageSize=30"
+    );
+  }
+);

--- a/airtable.ts
+++ b/airtable.ts
@@ -465,10 +465,9 @@ export class Airtable {
       baseId,
       encodeURIComponent(tableName),
       ...segments,
-      ...(hasAnyKey(query) ? ["?", stringify(query)] : []),
     ];
-
-    return urlSegments.join("/");
+    const queryString = hasAnyKey(query) ? "?" + stringify(query) : "";
+    return urlSegments.join("/").concat(queryString);
   }
 
   private async request<T>({

--- a/airtable.ts
+++ b/airtable.ts
@@ -430,7 +430,7 @@ export class Airtable {
     };
   }
 
-  private getRequestUrl(
+  getRequestUrl(
     query: Record<string, any> = {},
     ...segments: string[]
   ): string {

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,2 @@
 export { stringify } from "https://deno.land/std@0.68.0/node/querystring.ts";
+export { assertEquals } from "https://deno.land/std/testing/asserts.ts";


### PR DESCRIPTION
There is a bug in the query string concatenation in the `getRequestUrl` function. When you pass in options to the `select` function, e.g. `{ filterByFormula: "{Age}='27'" }`, the options aren't applied to the actual Airtable request. In this example, the request would return all records, rather than just those with `{Age}='27'`. This is because there are extra forward slashes surrounding the question mark separator between the rest of the URL and the query string.


`master`
```
https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans/?/filterByFormula={Age}='27'
                                                    ⬆️ 
```

`This PR`
```
https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans?filterByFormula={Age}='27'
                                                    ⬆️ 
```

I wrote some tests to check for myself that it works as I expect. However, to do that I made the `getRequestUrl` function public - which doesn't seem ideal. What would be a good way to test this? Alternatively, we could just remove the unit tests? 😅 Up to you!