### PR TITLE
fix: getRequestUrl for cases with a list of sort objects

### DIFF
--- a/airtable.test.ts
+++ b/airtable.test.ts
@@ -7,7 +7,7 @@ const airtable = new Airtable({
   tableName: "Humans",
 });
 
-Deno.test("getRequestUrl - applies an id as a URL segment", async () => {
+Deno.test("getRequestUrl - applies an id as a URL segment", () => {
   const id = "recXXXXXXXXXXXXXX";
   assertEquals(
     airtable.getRequestUrl({}, id),
@@ -17,7 +17,7 @@ Deno.test("getRequestUrl - applies an id as a URL segment", async () => {
 
 Deno.test(
   "getRequestUrl - applies filterByFormula as a query param",
-  async () => {
+  () => {
     assertEquals(
       decodeURIComponent(
         airtable.getRequestUrl({
@@ -30,17 +30,60 @@ Deno.test(
 );
 
 Deno.test(
+  "getRequestUrl - converts a list of sort objects to query params",
+  () => {
+    assertEquals(
+      airtable.getRequestUrl({
+        sort: [
+          {
+            field: 'Name',
+            direction: 'asc',
+          },
+          {
+            field: 'Age',
+            direction: 'desc',
+          },
+        ],
+      }),
+      "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans?sort[0][field]=Name&sort[0][direction]=asc&sort[1][field]=Age&sort[1][direction]=desc"
+    )
+  }
+)
+
+Deno.test(
+  "getRequestUrl - ignores an empty list of sort objects",
+  () => {
+    assertEquals(
+      airtable.getRequestUrl({
+        sort: [],
+      }),
+      "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans"
+    )
+  }
+)
+
+Deno.test(
   "getRequestUrl - applies multiple query params correctly",
-  async () => {
+  () => {
     assertEquals(
       decodeURIComponent(
         airtable.getRequestUrl({
           filterByFormula: "{Age}='27'",
           maxRecords: "50",
+          sort: [
+            {
+              field: 'Name',
+              direction: 'asc',
+            },
+            {
+              field: 'Age',
+              direction: 'desc',
+            },
+          ],
           pageSize: 30,
         })
       ),
-      "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans?filterByFormula={Age}='27'&maxRecords=50&pageSize=30"
+      "https://api.airtable.com/v0/appXXXXXXXXXXXXXX/Humans?sort[0][field]=Name&sort[0][direction]=asc&sort[1][field]=Age&sort[1][direction]=desc&filterByFormula={Age}='27'&maxRecords=50&pageSize=30"
     );
   }
 );

--- a/types.ts
+++ b/types.ts
@@ -46,15 +46,17 @@ export type FieldSetValue<T extends string = string> =
   | Field.Duration
   | Field.Rating;
 
+export interface SortSelectOption {
+  field: string;
+  direction?: "asc" | "desc";
+}
+
 export interface SelectOptions<T extends FieldSet> {
   fields?: (keyof T)[];
   filterByFormula?: string;
   maxRecords?: number;
   pageSize?: number;
-  sort?: {
-    field: string;
-    direction?: "asc" | "desc";
-  }[];
+  sort?: SortSelectOption[];
   view?: string;
   cellFormat?: "json" | "string";
   timeZone?: Timezone;


### PR DESCRIPTION
Hello.

As mentioned in the https://github.com/grikomsn/airtable-deno/issues/7, I made some changes to the function `getRequestUrl` in `airtable.ts`. I also moved the sort type to the `SortSelectOption` interface and wrote a couple of tests.

Please write your opinion. I can change anything that doesn't fit with your vision of the library :)