### PR TITLE
Add offset to SelectOptions

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,7 @@ export interface SelectOptions<T extends FieldSet> {
   cellFormat?: "json" | "string";
   timeZone?: Timezone;
   userLocale?: UserLocale;
+  offset?: string;
 }
 
 export interface SelectResult<T extends FieldSet> extends TableRecords<T> {


### PR DESCRIPTION
To fetch multiple pages of a query with `Airtable.select`, API users must include `offset` in all requests after their first request. This PR adds an `offset` key to the `SelectOptions<T>` type so that the type system allows users to do so.